### PR TITLE
ツールのバージョンアップ

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -L "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hado
     chmod +x hadolint
 
 # shellcheckのダウンロード
-RUN curl -L "https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.aarch64.tar.xz" | tar xJv
+RUN curl -L "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.aarch64.tar.xz" | tar xJv
 
 # 実行環境
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250414.0-minimal
@@ -46,13 +46,13 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /tmp/tools/actionlint /usr/local/bin/
 COPY --from=builder /tmp/tools/ghalint /usr/local/bin/
 COPY --from=builder /tmp/tools/hadolint /usr/local/bin/
-COPY --from=builder /tmp/tools/shellcheck-v0.8.0/shellcheck /usr/local/bin/
+COPY --from=builder /tmp/tools/shellcheck-v0.10.0/shellcheck /usr/local/bin/
 
 # 開発に必要な基本ツールのインストール
 RUN dnf update -y && \
-    dnf install -y \
+    dnf --releasever=latest install -y \
     findutils-4.8.0 \
-    git-2.40.1 \
+    git-2.47.1 \
     glibc-locale-source-2.34 \
     nodejs-18.20.6 \
     nodejs-npm-10.8.2 \
@@ -67,7 +67,7 @@ RUN dnf update -y && \
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 # AWS CLIのダウンロードとインストール
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.26.4.zip" -o "awscliv2.zip" && \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.27.2.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli && \
     chmod +x /usr/local/bin/aws* && \
@@ -84,7 +84,8 @@ RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.34.1 && \
     rm -rf /root/.local/pipx/logs/*
 
 # NPMパッケージのインストール（runtimeステージで実行）
-RUN npm install -g --omit=dev --no-progress markdownlint-cli2@0.17.2 && \
+RUN npm install -g --omit=dev --no-progress npm@10.9.2 && \
+    npm install -g --omit=dev --no-progress markdownlint-cli2@0.17.2 && \
     npm install -g --omit=dev --no-progress secretlint@9.3.1 @secretlint/secretlint-rule-preset-recommend@9.3.1 && \
     npm cache clean --force && \
     rm -rf /root/.npm/_logs

--- a/README.md
+++ b/README.md
@@ -18,16 +18,17 @@ The DevContainer is configured with Linters and VS Code extensions.
 | Software | Version | Notes |
 | --- | ---: | --- |
 | actionlint | 1.7.7 | Linter for GitHub Actions |
-| awscli | 2.26.4 | AWS CLI |
+| awscli | 2.27.2 | AWS CLI |
 | ghalint | 1.3.0 | Linter for GitHub Actions |
 | hadolint | 2.12.0 | Linter for Dockerfile |
-| shellcheck | 0.8.0 | Linter for Bash |
+| shellcheck | 0.10.0 | Linter for Bash |
 
 ### Installed via npm command
 
 | Software | Version | Notes |
 | --- | ---: | --- |
 | markdownlint-cli2 | 0.17.2 | Linter for Markdown |
+| npm | 10.9.2 | Node.js package manager |
 | SecretLint | 9.3.1 | Secret detection tool |
 
 ### Installed via pipx command
@@ -42,7 +43,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 | Package Name | Version | Notes |
 | --- | ---: | --- |
 | findutils | 4.8.0 | File search utilities |
-| git | 2.40.1 | Git command |
+| git | 2.47.1 | Git command |
 | glibc-locale-source | 2.34 | Source for generating locale data |
 | nodejs | 18.20.6 | Node.js runtime |
 | nodejs-npm | 10.8.2 | Node.js package manager (standard npm package manager) |


### PR DESCRIPTION
- awscli 2.26.4 -> 2.27.2
- git 2.40.1 -> 2.47.1
- npm 10.8.2 -> 10.9.2
- shellcheck 0.8.0 -> 0.10.0