### PR TITLE
Update AWS CLI and cfn-lint versions, add new Linter extension

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -107,7 +107,7 @@ RUN dnf update -y && \
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 # AWS CLIのダウンロードとインストール
-ARG AWSCLI_VERSION=2.27.2
+ARG AWSCLI_VERSION=2.27.12
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o awscliv2.zip; \
@@ -127,7 +127,7 @@ RUN python3.12 -m pip install --no-cache-dir pipx==1.7.1 && \
     python3.12 -m pipx ensurepath
 
 # Python関連ツールのインストール
-RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.34.1 && \
+RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.35.1 && \
     pipx install --pip-args='--no-cache-dir' yamllint==1.37.0 && \
     rm -rf /root/.local/pipx/logs/*
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,14 +7,16 @@
 		"--name", "static-analysis",
 		"--hostname", "static-analysis"
 	],
+	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=consistent",
 	"customizations": {
 		"vscode": {
 			"extensions": [
 				"amazonwebservices.aws-toolkit-vscode",
-				"aws-scripting-guy.cform",
 				"charliermarsh.ruff",
 				"DavidAnson.vscode-markdownlint",
 				"exiasr.hadolint",
+				"fnando.linter",
 				"github.vscode-github-actions",
 				"github.copilot",
 				"github.copilot-chat",
@@ -22,7 +24,6 @@
 				"mechatroner.rainbow-csv",
 				"ms-ceintl.vscode-language-pack-ja",
 				"ms-python.python",
-				"redhat.vscode-yaml",
 				"timonwong.shellcheck"
 			],
 			"settings": {
@@ -35,6 +36,28 @@
 				},
 				"files.exclude": {
 					"**/.git": false
+				},
+				"linter.linters": {
+					"yamllint": {
+						"capabilities": [
+							"ignore-line"
+						],
+						"command": [ 
+							"yamllint", 
+							"--format", 
+							"colored", 
+							"--config-file", 
+							"/workspace/config/yamllint_config.yml", 
+							"-" 
+						],
+						"enabled": true,
+						"languages": [
+							"github-actions-workflow",
+							"yaml"
+						],
+						"name": "yamllint",
+						"url": "https://github.com/adrienverge/yamllint"
+					}
 				},
 				"markdownlint.config": {
 					"MD013": {

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 | Software | Version | Notes |
 | --- | ---: | --- |
 | actionlint | 1.7.7 | Linter for GitHub Actions |
-| awscli | 2.27.2 | AWS CLI |
+| awscli | 2.27.12 | AWS CLI |
 | ghalint | 1.3.0 | Linter for GitHub Actions |
 | hadolint | 2.12.0 | Linter for Dockerfile |
 | shellcheck | 0.10.0 | Linter for Bash |
@@ -35,7 +35,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 | Software | Version | Notes |
 | --- | ---: | --- |
-| cfn-lint | 1.34.1 | Linter for CloudFormation |
+| cfn-lint | 1.35.1 | Linter for CloudFormation |
 | yamllint | 1.37.0 | Linter for YAML |
 
 ### Installed via dnf command
@@ -59,10 +59,10 @@ The DevContainer is configured with Linters and VS Code extensions.
 | Extension | Notes |
 | --- | --- |
 | amazonwebservices.aws-toolkit-vscode | AWS extension |
-| aws-scripting-guy.cform | CloudFormation extension |
 | charliermarsh.ruff | Linter for Python |
 | DavidAnson.vscode-markdownlint | Linter for Markdown |
 | exiasr.hadolint | Linter for Dockerfile |
+| fnando.linter | An extension that brings together various Linters. Used by yamllint |
 | github.vscode-github-actions | GitHub Actions extension |
 | github.copilot | GitHub Copilot extension |
 | github.copilot-chat | GitHub Copilot Chat extension |
@@ -70,7 +70,6 @@ The DevContainer is configured with Linters and VS Code extensions.
 | mechatroner.rainbow-csv | CSV extension |
 | ms-ceintl.vscode-language-pack-ja | Japanese language extension |
 | ms-python.python | Python extension |
-| redhat.vscode-yaml | YAML extension |
 | timonwong.shellcheck | Linter for Bash |
 
 ## Setup Instructions
@@ -84,7 +83,7 @@ code --install-extension ms-vscode-remote.remote-containers
 (When using WSL2 on Windows)  
 In the Dev Containers extension settings (@ext:ms-vscode-remote.remote-containers), check "Execute In WSL".  
 
-![Open a Remote Window](./images/VSCode_image_01.png)  
+![Check "Execute In WSL"](./images/VSCode_image_01.png)  
 
 Download the repository.  
 Open the downloaded folder in VS Code.  

--- a/tests/docker_image_test.py
+++ b/tests/docker_image_test.py
@@ -67,14 +67,14 @@ def test_aws_cli_is_installed(host: Host) -> None:
     """Test if AWS CLI is installed and has the correct version."""
     cmd = host.run("aws --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "2.27.2" in cmd.stdout  # noqa: S101
+    assert "2.27.12" in cmd.stdout  # noqa: S101
 
 
 def test_cfn_lint_is_installed(host: Host) -> None:
     """Test if cfn-lint is installed and has the correct version."""
     cmd = host.run("cfn-lint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.34.1" in cmd.stdout  # noqa: S101
+    assert "1.35.1" in cmd.stdout  # noqa: S101
 
 
 def test_yamllint_is_installed(host: Host) -> None:


### PR DESCRIPTION
Update the AWS CLI and cfn-lint to their latest versions and reflect these changes in the README. Add a new Linter extension to the devcontainer configuration. Adjust tests to verify the updated versions.