### PR TITLE
Update AWS CLI and cfn-lint versions, add new Linter extension

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -107,7 +107,7 @@ RUN dnf update -y && \
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 # AWS CLIのダウンロードとインストール
-ARG AWSCLI_VERSION=2.27.2
+ARG AWSCLI_VERSION=2.27.12
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o awscliv2.zip; \
@@ -127,7 +127,7 @@ RUN python3.12 -m pip install --no-cache-dir pipx==1.7.1 && \
     python3.12 -m pipx ensurepath
 
 # Python関連ツールのインストール
-RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.34.1 && \
+RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.35.1 && \
     pipx install --pip-args='--no-cache-dir' yamllint==1.37.0 && \
     rm -rf /root/.local/pipx/logs/*
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
 			"extensions": [
 				"amazonwebservices.aws-toolkit-vscode",
 				"aws-scripting-guy.cform",
+				"charliermarsh.ruff",
 				"DavidAnson.vscode-markdownlint",
 				"exiasr.hadolint",
 				"github.vscode-github-actions",
@@ -20,10 +21,18 @@
 				"kddejong.vscode-cfn-lint",
 				"mechatroner.rainbow-csv",
 				"ms-ceintl.vscode-language-pack-ja",
+				"ms-python.python",
 				"redhat.vscode-yaml",
 				"timonwong.shellcheck"
 			],
 			"settings": {
+				"[python]": {
+					"editor.formatOnSave": true,
+					"editor.codeActionsOnSave": {
+						"source.organizeImports": "explicit"
+					},
+					"editor.defaultFormatter": "charliermarsh.ruff"
+				},
 				"files.exclude": {
 					"**/.git": false
 				},
@@ -33,7 +42,11 @@
 						"code_block_line_length": 140,
 						"tables": true
 					}
-				}
+				},
+				"ruff.lint.ignore": [
+					"INP001" // __init__.py の存在確認を除外
+				],
+				"ruff.lint.select": ["ALL"]
 			}
 		}
 	}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,14 +7,16 @@
 		"--name", "static-analysis",
 		"--hostname", "static-analysis"
 	],
+	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=consistent",
 	"customizations": {
 		"vscode": {
 			"extensions": [
 				"amazonwebservices.aws-toolkit-vscode",
-				"aws-scripting-guy.cform",
 				"charliermarsh.ruff",
 				"DavidAnson.vscode-markdownlint",
 				"exiasr.hadolint",
+				"fnando.linter",
 				"github.vscode-github-actions",
 				"github.copilot",
 				"github.copilot-chat",
@@ -22,7 +24,6 @@
 				"mechatroner.rainbow-csv",
 				"ms-ceintl.vscode-language-pack-ja",
 				"ms-python.python",
-				"redhat.vscode-yaml",
 				"timonwong.shellcheck"
 			],
 			"settings": {
@@ -35,6 +36,28 @@
 				},
 				"files.exclude": {
 					"**/.git": false
+				},
+				"linter.linters": {
+					"yamllint": {
+						"capabilities": [
+							"ignore-line"
+						],
+						"command": [ 
+							"yamllint", 
+							"--format", 
+							"colored", 
+							"--config-file", 
+							"/workspace/config/yamllint_config.yml", 
+							"-" 
+						],
+						"enabled": true,
+						"languages": [
+							"github-actions-workflow",
+							"yaml"
+						],
+						"name": "yamllint",
+						"url": "https://github.com/adrienverge/yamllint"
+					}
 				},
 				"markdownlint.config": {
 					"MD013": {

--- a/.github/workflows/DockerImageScan.yml
+++ b/.github/workflows/DockerImageScan.yml
@@ -34,6 +34,19 @@ jobs:
         run: |
           docker build -f .devcontainer/Dockerfile -t dev-container:test .
 
+      - name: Install Testinfra
+        run: |
+          cd /opt
+          python3 -m venv testinfra
+          source testinfra/bin/activate
+          python3 -m pip install pytest-testinfra==10.2.2
+
+      - name: Run Testinfra tests
+        run: |
+          source /opt/testinfra/bin/activate
+          py.test -v tests/docker_image_test.py
+          deactivate
+
       - name: Install Syft (SBOM generator)
         run: |
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/v1.23.1/install.sh | sh -s -- -b /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 | Software | Version | Notes |
 | --- | ---: | --- |
 | actionlint | 1.7.7 | Linter for GitHub Actions |
-| awscli | 2.27.2 | AWS CLI |
+| awscli | 2.27.12 | AWS CLI |
 | ghalint | 1.3.0 | Linter for GitHub Actions |
 | hadolint | 2.12.0 | Linter for Dockerfile |
 | shellcheck | 0.10.0 | Linter for Bash |
@@ -35,7 +35,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 | Software | Version | Notes |
 | --- | ---: | --- |
-| cfn-lint | 1.34.1 | Linter for CloudFormation |
+| cfn-lint | 1.35.1 | Linter for CloudFormation |
 | yamllint | 1.37.0 | Linter for YAML |
 
 ### Installed via dnf command
@@ -59,10 +59,10 @@ The DevContainer is configured with Linters and VS Code extensions.
 | Extension | Notes |
 | --- | --- |
 | amazonwebservices.aws-toolkit-vscode | AWS extension |
-| aws-scripting-guy.cform | CloudFormation extension |
 | charliermarsh.ruff | Linter for Python |
 | DavidAnson.vscode-markdownlint | Linter for Markdown |
 | exiasr.hadolint | Linter for Dockerfile |
+| fnando.linter | An extension that brings together various Linters. Used by yamllint |
 | github.vscode-github-actions | GitHub Actions extension |
 | github.copilot | GitHub Copilot extension |
 | github.copilot-chat | GitHub Copilot Chat extension |
@@ -70,7 +70,6 @@ The DevContainer is configured with Linters and VS Code extensions.
 | mechatroner.rainbow-csv | CSV extension |
 | ms-ceintl.vscode-language-pack-ja | Japanese language extension |
 | ms-python.python | Python extension |
-| redhat.vscode-yaml | YAML extension |
 | timonwong.shellcheck | Linter for Bash |
 
 ## Setup Instructions
@@ -84,7 +83,7 @@ code --install-extension ms-vscode-remote.remote-containers
 (When using WSL2 on Windows)  
 In the Dev Containers extension settings (@ext:ms-vscode-remote.remote-containers), check "Execute In WSL".  
 
-![Open a Remote Window](./images/VSCode_image_01.png)  
+![Check "Execute In WSL"](./images/VSCode_image_01.png)  
 
 Download the repository.  
 Open the downloaded folder in VS Code.  

--- a/README.md
+++ b/README.md
@@ -56,20 +56,22 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 ## VS Code Extensions Used in DevContainer
 
-| Extension | Version | Notes |
-| --- | ---: | --- |
-| amazonwebservices.aws-toolkit-vscode | 3.53.0 | AWS extension |
-| aws-scripting-guy.cform | 0.0.24 | CloudFormation extension |
-| DavidAnson.vscode-markdownlint | 0.59.0 | Linter for Markdown |
-| exiasr.hadolint | 1.1.2 | Linter for Dockerfile |
-| github.vscode-github-actions | 0.27.1 | GitHub Actions extension |
-| github.copilot | 1.297.0 | GitHub Copilot extension |
-| github.copilot-chat | 0.26.2 | GitHub Copilot Chat extension |
-| kddejong.vscode-cfn-lint | 0.26.4 | Linter for CloudFormation |
-| mechatroner.rainbow-csv | 3.19.0 | CSV extension |
-| ms-ceintl.vscode-language-pack-ja | 1.99.2025040209 | Japanese language extension |
-| redhat.vscode-yaml | 1.17.0 | YAML extension |
-| timonwong.shellcheck | 0.37.3 | Linter for Bash |
+| Extension | Notes |
+| --- | --- |
+| amazonwebservices.aws-toolkit-vscode | AWS extension |
+| aws-scripting-guy.cform | CloudFormation extension |
+| charliermarsh.ruff | Linter for Python |
+| DavidAnson.vscode-markdownlint | Linter for Markdown |
+| exiasr.hadolint | Linter for Dockerfile |
+| github.vscode-github-actions | GitHub Actions extension |
+| github.copilot | GitHub Copilot extension |
+| github.copilot-chat | GitHub Copilot Chat extension |
+| kddejong.vscode-cfn-lint | Linter for CloudFormation |
+| mechatroner.rainbow-csv | CSV extension |
+| ms-ceintl.vscode-language-pack-ja | Japanese language extension |
+| ms-python.python | Python extension |
+| redhat.vscode-yaml | YAML extension |
+| timonwong.shellcheck | Linter for Bash |
 
 ## Setup Instructions
 

--- a/tests/docker_image_test.py
+++ b/tests/docker_image_test.py
@@ -67,14 +67,14 @@ def test_aws_cli_is_installed(host: Host) -> None:
     """Test if AWS CLI is installed and has the correct version."""
     cmd = host.run("aws --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "2.27.2" in cmd.stdout  # noqa: S101
+    assert "2.27.12" in cmd.stdout  # noqa: S101
 
 
 def test_cfn_lint_is_installed(host: Host) -> None:
     """Test if cfn-lint is installed and has the correct version."""
     cmd = host.run("cfn-lint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.34.1" in cmd.stdout  # noqa: S101
+    assert "1.35.1" in cmd.stdout  # noqa: S101
 
 
 def test_yamllint_is_installed(host: Host) -> None:

--- a/tests/docker_image_test.py
+++ b/tests/docker_image_test.py
@@ -1,0 +1,115 @@
+"""Test module for verifying the Docker image configuration and installed tools."""
+
+import subprocess
+
+import pytest
+import testinfra
+from testinfra.host import Host
+
+
+@pytest.fixture(scope="session")
+def host() -> Host:
+    """Create a Docker container for testing and yield the host object."""
+    image_name = "dev-container:test"
+    docker_bin = "/usr/bin/docker"
+    # コンテナが既に存在しているか確認し、なければ起動
+    docker_id = (
+        subprocess.check_output(  # noqa: S603
+            [
+                docker_bin,
+                "run",
+                "-d",
+                "--rm",  # テスト終了後に自動削除
+                image_name,
+                "sleep",
+                "600",  # テスト中にコンテナが終了しないようにする
+            ],
+        )
+        .decode()
+        .strip()
+    )
+    try:
+        yield testinfra.get_host("docker://" + docker_id)
+    finally:
+        # テスト後に必ずコンテナを削除
+        subprocess.call([docker_bin, "rm", "-f", docker_id])  # noqa: S603
+
+
+def test_actionlint_is_installed(host: Host) -> None:
+    """Test if actionlint is installed and has the correct version."""
+    cmd = host.run("actionlint --version")
+    assert cmd.rc == 0  # noqa: S101
+    assert "1.7.7" in cmd.stdout  # noqa: S101
+
+
+def test_ghalint_is_installed(host: Host) -> None:
+    """Test if ghalint is installed and has the correct version."""
+    cmd = host.run("ghalint -v")
+    assert cmd.rc == 0  # noqa: S101
+    assert "1.3.0" in cmd.stdout  # noqa: S101
+
+
+def test_hadolint_is_installed(host: Host) -> None:
+    """Test if hadolint is installed and has the correct version."""
+    cmd = host.run("hadolint --version")
+    assert cmd.rc == 0  # noqa: S101
+    assert "2.12.0" in cmd.stdout  # noqa: S101
+
+
+def test_shellcheck_is_installed(host: Host) -> None:
+    """Test if shellcheck is installed and has the correct version."""
+    cmd = host.run("shellcheck --version")
+    assert cmd.rc == 0  # noqa: S101
+    assert "0.10.0" in cmd.stdout  # noqa: S101
+
+
+def test_aws_cli_is_installed(host: Host) -> None:
+    """Test if AWS CLI is installed and has the correct version."""
+    cmd = host.run("aws --version")
+    assert cmd.rc == 0  # noqa: S101
+    assert "2.27.2" in cmd.stdout  # noqa: S101
+
+
+def test_cfn_lint_is_installed(host: Host) -> None:
+    """Test if cfn-lint is installed and has the correct version."""
+    cmd = host.run("cfn-lint --version")
+    assert cmd.rc == 0  # noqa: S101
+    assert "1.34.1" in cmd.stdout  # noqa: S101
+
+
+def test_yamllint_is_installed(host: Host) -> None:
+    """Test if yamllint is installed and has the correct version."""
+    cmd = host.run("yamllint --version")
+    assert cmd.rc == 0  # noqa: S101
+    assert "1.37.0" in cmd.stdout  # noqa: S101
+
+
+def test_markdownlint_is_installed(host: Host) -> None:
+    """Test if markdownlint is installed and has the correct version."""
+    cmd = host.run("markdownlint-cli2 --version")
+    assert cmd.rc == 0  # noqa: S101
+    assert "0.17.2" in cmd.stdout  # noqa: S101
+
+
+def test_secretlint_is_installed(host: Host) -> None:
+    """Test if secretlint is installed and has the correct version."""
+    cmd = host.run("secretlint --version")
+    assert cmd.rc == 0  # noqa: S101
+    assert "9.3.1" in cmd.stdout  # noqa: S101
+
+
+FILE_MODE_EXECUTABLE = 0o755
+
+
+def test_binaries_exist(host: Host) -> None:
+    """Test if the required binaries exist and have the correct permissions."""
+    binaries = [
+        "/usr/local/bin/actionlint",
+        "/usr/local/bin/ghalint",
+        "/usr/local/bin/hadolint",
+        "/usr/local/bin/shellcheck",
+        "/usr/local/bin/aws",
+    ]
+    for binary in binaries:
+        assert host.file(binary).exists  # noqa: S101
+        assert host.file(binary).mode == FILE_MODE_EXECUTABLE  # noqa: S101


### PR DESCRIPTION
Update the AWS CLI and cfn-lint to their latest versions and reflect these changes in the README. Add a new Linter extension to the devcontainer configuration. Adjust tests to verify the updated versions.