### PR TITLE
Bump amazonlinux/amazonlinux from 2023.7.20250512.0-minimal to 2023.7.20250527.1-minimal in /.devcontainer (#15)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # ビルドステージ
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250512.0-minimal AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250527.1-minimal AS builder
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -30,7 +30,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # ghalintのダウンロード
-ARG GHALINT_VERSION=1.3.0
+ARG GHALINT_VERSION=1.4.1
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -LO "https://github.com/suzuki-shunsuke/ghalint/releases/download/v${GHALINT_VERSION}/ghalint_${GHALINT_VERSION}_linux_amd64.tar.gz" && \
@@ -68,7 +68,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # 実行環境
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250512.0-minimal
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250527.1-minimal
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -94,9 +94,9 @@ RUN dnf update -y && \
     git-2.47.1 \
     glibc-locale-source-2.34 \
     gzip-1.12 \
-    nodejs-18.20.6 \
-    nodejs-npm-10.8.2 \
-    python3.12-3.12.9 \
+    nodejs20-20.19.1 \
+    nodejs20-npm-10.8.2 \
+    python3.12-3.12.10 \
     python3.12-pip-23.2.1 \
     tar-1.34 \
     unzip-6.0 \
@@ -107,7 +107,7 @@ RUN dnf update -y && \
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 # AWS CLIのダウンロードとインストール
-ARG AWSCLI_VERSION=2.27.12
+ARG AWSCLI_VERSION=2.27.32
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o awscliv2.zip; \
@@ -122,18 +122,19 @@ RUN BUILDARCH=$(uname -m) && \
     rm -rf awscliv2.zip aws
 
 # pipxのインストールと環境設定
-RUN python3.12 -m pip install --no-cache-dir pipx==1.7.1 && \
-    python3.12 -m pip install --no-cache-dir setuptools==70.0.0 && \
+RUN python3.12 -m pip install --no-cache-dir -U pip==25.1.1 && \
+    python3.12 -m pip install --no-cache-dir pipx==1.7.1 && \
+    python3.12 -m pip install --no-cache-dir setuptools==78.1.1 && \
     python3.12 -m pipx ensurepath
 
 # Python関連ツールのインストール
-RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.35.1 && \
-    pipx install --pip-args='--no-cache-dir' yamllint==1.37.0 && \
+RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.35.4 && \
+    pipx install --pip-args='--no-cache-dir' yamllint==1.37.1 && \
     rm -rf /root/.local/pipx/logs/*
 
 # NPMパッケージのインストール（runtimeステージで実行）
-RUN npm install -g --omit=dev --no-progress npm@10.9.2 && \
-    npm install -g --omit=dev --no-progress markdownlint-cli2@0.17.2 && \
-    npm install -g --omit=dev --no-progress secretlint@9.3.1 @secretlint/secretlint-rule-preset-recommend@9.3.1 && \
+RUN npm install -g --omit=dev --no-progress npm@11.4.1 && \
+    npm install -g --omit=dev --no-progress markdownlint-cli2@0.18.1 && \
+    npm install -g --omit=dev --no-progress secretlint@9.3.4 @secretlint/secretlint-rule-preset-recommend@9.3.1 && \
     npm cache clean --force && \
     rm -rf /root/.npm/_logs

--- a/.github/workflows/DockerImageScan.yml
+++ b/.github/workflows/DockerImageScan.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install Syft (SBOM generator)
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/v1.23.1/install.sh | sh -s -- -b /usr/local/bin
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/v1.27.0/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Generate SBOM (CycloneDX format)
         run: |
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install Grype (Vulnerability scanner)
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/v0.91.2/install.sh | sh -s -- -b /usr/local/bin
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/v0.92.2/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Scan SBOM with Grype
         run: |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 ## DevContainer Base Image
 
-- public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250428.1-minimal
+- public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250527.1-minimal
   - Using Amazon Linux 2023 minimal image
   - Using `dnf` as package manager
 
@@ -18,8 +18,8 @@ The DevContainer is configured with Linters and VS Code extensions.
 | Software | Version | Notes |
 | --- | ---: | --- |
 | actionlint | 1.7.7 | Linter for GitHub Actions |
-| awscli | 2.27.12 | AWS CLI |
-| ghalint | 1.3.0 | Linter for GitHub Actions |
+| awscli | 2.27.32 | AWS CLI |
+| ghalint | 1.4.1 | Linter for GitHub Actions |
 | hadolint | 2.12.0 | Linter for Dockerfile |
 | shellcheck | 0.10.0 | Linter for Bash |
 
@@ -27,16 +27,16 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 | Software | Version | Notes |
 | --- | ---: | --- |
-| markdownlint-cli2 | 0.17.2 | Linter for Markdown |
-| npm | 10.9.2 | Node.js package manager |
-| SecretLint | 9.3.1 | Secret detection tool |
+| markdownlint-cli2 | 0.18.1 | Linter for Markdown |
+| npm | 11.4.1 | Node.js package manager |
+| SecretLint | 9.3.4 | Secret detection tool |
 
 ### Installed via pipx command
 
 | Software | Version | Notes |
 | --- | ---: | --- |
-| cfn-lint | 1.35.1 | Linter for CloudFormation |
-| yamllint | 1.37.0 | Linter for YAML |
+| cfn-lint | 1.35.4 | Linter for CloudFormation |
+| yamllint | 1.37.1 | Linter for YAML |
 
 ### Installed via dnf command
 
@@ -46,9 +46,9 @@ The DevContainer is configured with Linters and VS Code extensions.
 | git | 2.47.1 | Git command |
 | glibc-locale-source | 2.34 | Source for generating locale data |
 | gzip | 1.12 | Compression tool |
-| nodejs | 18.20.6 | Node.js runtime |
-| nodejs-npm | 10.8.2 | Node.js package manager (standard npm package manager) |
-| python3.12 | 3.12.9 | Python 3.12 |
+| nodejs20 | 20.19.1 | Node.js runtime |
+| nodejs20-npm | 10.8.2 | Node.js package manager (standard npm package manager) |
+| python3.12 | 3.12.10 | Python 3.12 |
 | python3.12-pip | 23.2.1 | pip for Python 3.12 |
 | tar | 1.34 | Archive tool |
 | unzip | 6.0 | Decompression tool |

--- a/tests/docker_image_test.py
+++ b/tests/docker_image_test.py
@@ -46,7 +46,7 @@ def test_ghalint_is_installed(host: Host) -> None:
     """Test if ghalint is installed and has the correct version."""
     cmd = host.run("ghalint -v")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.3.0" in cmd.stdout  # noqa: S101
+    assert "1.4.1" in cmd.stdout  # noqa: S101
 
 
 def test_hadolint_is_installed(host: Host) -> None:
@@ -67,35 +67,35 @@ def test_aws_cli_is_installed(host: Host) -> None:
     """Test if AWS CLI is installed and has the correct version."""
     cmd = host.run("aws --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "2.27.12" in cmd.stdout  # noqa: S101
+    assert "2.27.32" in cmd.stdout  # noqa: S101
 
 
 def test_cfn_lint_is_installed(host: Host) -> None:
     """Test if cfn-lint is installed and has the correct version."""
     cmd = host.run("cfn-lint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.35.1" in cmd.stdout  # noqa: S101
+    assert "1.35.4" in cmd.stdout  # noqa: S101
 
 
 def test_yamllint_is_installed(host: Host) -> None:
     """Test if yamllint is installed and has the correct version."""
     cmd = host.run("yamllint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.37.0" in cmd.stdout  # noqa: S101
+    assert "1.37.1" in cmd.stdout  # noqa: S101
 
 
 def test_markdownlint_is_installed(host: Host) -> None:
     """Test if markdownlint is installed and has the correct version."""
     cmd = host.run("markdownlint-cli2 --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "0.17.2" in cmd.stdout  # noqa: S101
+    assert "0.18.1" in cmd.stdout  # noqa: S101
 
 
 def test_secretlint_is_installed(host: Host) -> None:
     """Test if secretlint is installed and has the correct version."""
     cmd = host.run("secretlint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "9.3.1" in cmd.stdout  # noqa: S101
+    assert "9.3.4" in cmd.stdout  # noqa: S101
 
 
 FILE_MODE_EXECUTABLE = 0o755


### PR DESCRIPTION
* Bump amazonlinux/amazonlinux in /.devcontainer

Bumps amazonlinux/amazonlinux from 2023.7.20250512.0-minimal to 2023.7.20250527.1-minimal.

---
updated-dependencies:
- dependency-name: amazonlinux/amazonlinux
  dependency-version: 2023.7.20250527.1-minimal
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* Updated Dockerfile and test dependencies, corrected README

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: jay34986 <113755559+jay34986@users.noreply.github.com>

---------

- Update the following version of Dockerfile
  - ghalint : 1.3.0 -> 1.4.1
  - nodejs : 18.20.6 -> 20.19.1
  - python : 3.12.9 -> 3.12.10
  - AWS CLI : 2.27.12 -> 2.27.32
  - cfn-lint : 1.35.1 -> 1.35.4
  - yamllint : 1.37.0 -> 1.37.1
  - markdownlint-cli2 : 0.17.2 -> 0.18.1
  - secretlint : 9.3.1 -> 9.3.4

- Updated the following versions used in image scanning:
  - syft : 1.23.1 -> 1.27.0
  - grype : 0.91.2 -> 0.92.2