### PR TITLE
Bump docker/setup-buildx-action from 3.10.0 to 3.11.1 (#20)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,7 +30,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # ghalintのダウンロード
-ARG GHALINT_VERSION=1.4.1
+ARG GHALINT_VERSION=1.5.1
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -LO "https://github.com/suzuki-shunsuke/ghalint/releases/download/v${GHALINT_VERSION}/ghalint_${GHALINT_VERSION}_linux_amd64.tar.gz" && \
@@ -128,7 +128,7 @@ RUN python3.12 -m pip install --no-cache-dir -U pip==25.1.1 && \
     python3.12 -m pipx ensurepath
 
 # Python関連ツールのインストール
-RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.36.0 && \
+RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.36.1 && \
     pipx install --pip-args='--no-cache-dir' yamllint==1.37.1 && \
     rm -rf /root/.local/pipx/logs/*
 

--- a/.github/workflows/DockerImageScan.yml
+++ b/.github/workflows/DockerImageScan.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: "false"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
 
       - name: Build Docker image
         run: |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 | --- | ---: | --- |
 | actionlint | 1.7.7 | Linter for GitHub Actions |
 | awscli | 2.27.35 | AWS CLI |
-| ghalint | 1.4.1 | Linter for GitHub Actions |
+| ghalint | 1.5.1 | Linter for GitHub Actions |
 | hadolint | 2.12.0 | Linter for Dockerfile |
 | shellcheck | 0.10.0 | Linter for Bash |
 
@@ -35,7 +35,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 | Software | Version | Notes |
 | --- | ---: | --- |
-| cfn-lint | 1.36.0 | Linter for CloudFormation |
+| cfn-lint | 1.36.1 | Linter for CloudFormation |
 | yamllint | 1.37.1 | Linter for YAML |
 
 ### Installed via dnf command

--- a/tests/docker_image_test.py
+++ b/tests/docker_image_test.py
@@ -46,7 +46,7 @@ def test_ghalint_is_installed(host: Host) -> None:
     """Test if ghalint is installed and has the correct version."""
     cmd = host.run("ghalint -v")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.4.1" in cmd.stdout  # noqa: S101
+    assert "1.5.1" in cmd.stdout  # noqa: S101
 
 
 def test_hadolint_is_installed(host: Host) -> None:
@@ -74,7 +74,7 @@ def test_cfn_lint_is_installed(host: Host) -> None:
     """Test if cfn-lint is installed and has the correct version."""
     cmd = host.run("cfn-lint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.36.0" in cmd.stdout  # noqa: S101
+    assert "1.36.1" in cmd.stdout  # noqa: S101
 
 
 def test_yamllint_is_installed(host: Host) -> None:


### PR DESCRIPTION
* Bump docker/setup-buildx-action from 3.10.0 to 3.11.1

Bumps [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action) from 3.10.0 to 3.11.1.
- [Release notes](https://github.com/docker/setup-buildx-action/releases)
- [Commits](https://github.com/docker/setup-buildx-action/compare/b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2...e468171a9de216ec08956ac3ada2f0791b6bd435)

---
updated-dependencies:
- dependency-name: docker/setup-buildx-action dependency-version: 3.11.1 dependency-type: direct:production update-type: version-update:semver-minor ...



* Updated ghalint and cfn-lint versions

---------