### PR TITLE
Bump amazonlinux/amazonlinux from 2023.7.20250609.0-minimal to 2023.7…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # ビルドステージ
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250609.0-minimal AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250623.1-minimal AS builder
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -68,7 +68,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # 実行環境
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250609.0-minimal
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250623.1-minimal
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/.github/workflows/MarkdownLint.yml
+++ b/.github/workflows/MarkdownLint.yml
@@ -9,6 +9,7 @@ on:  # yamllint disable-line rule:truthy
       - develop
     paths:
       - "**/*.md"
+      - "!.github/prompts/*.md"
   workflow_dispatch:
 
 defaults:
@@ -30,5 +31,7 @@ jobs:
       - name: Lint Markdown files
         uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e  # v20.0.0
         with:
-          globs: '**/*.md'
+          globs: |
+            '**/*.md'
+            '!.github/prompts/*.md'
           config: config/.markdownlint.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.github/prompts/*

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 ## DevContainer Base Image
 
-- public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250609.0-minimal
+- public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250623.1-minimal
   - Using Amazon Linux 2023 minimal image
   - Using `dnf` as package manager
 


### PR DESCRIPTION
….20250623.1-minimal in /.devcontainer (#22)

* Bump amazonlinux/amazonlinux in /.devcontainer

Bumps amazonlinux/amazonlinux from 2023.7.20250609.0-minimal to 2023.7.20250623.1-minimal.

---
updated-dependencies:
- dependency-name: amazonlinux/amazonlinux dependency-version: 2023.7.20250623.1-minimal dependency-type: direct:production update-type: version-update:semver-patch ...



* Update Amazon Linux image

---------