### PR TITLE
Change Grype scan output format to SARIF and add report upload step

### DIFF
--- a/.github/workflows/DockerImageScan.yml
+++ b/.github/workflows/DockerImageScan.yml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -61,4 +62,10 @@ jobs:
 
       - name: Scan SBOM with Grype
         run: |
-          grype --only-fixed sbom:sbom.json
+          grype --only-fixed sbom:sbom.json -o sarif=grype.sarif
+
+      - name: Upload Grype report
+        if: always() && (hashFiles('grype.sarif') != '')
+        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b  # v3.29.2
+        with:
+          sarif_file: grype.sarif


### PR DESCRIPTION
Modify the Grype scan to output in SARIF format and include a step to upload the report. Additionally, grant permissions for security events.