### PR TITLE
Bump amazonlinux/amazonlinux from 2023.7.20250623.1-minimal to 2023.8…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # ビルドステージ
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250623.1-minimal AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250715.0-minimal AS builder
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -30,7 +30,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # ghalintのダウンロード
-ARG GHALINT_VERSION=1.5.1
+ARG GHALINT_VERSION=1.5.3
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -LO "https://github.com/suzuki-shunsuke/ghalint/releases/download/v${GHALINT_VERSION}/ghalint_${GHALINT_VERSION}_linux_amd64.tar.gz" && \
@@ -68,7 +68,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # 実行環境
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250623.1-minimal
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250715.0-minimal
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -96,7 +96,7 @@ RUN dnf update -y && \
     gzip-1.12 \
     nodejs20-20.19.2 \
     nodejs20-npm-10.8.2 \
-    python3.12-3.12.10 \
+    python3.12-3.12.11 \
     python3.12-pip-23.2.1 \
     tar-1.34 \
     unzip-6.0 \
@@ -107,7 +107,7 @@ RUN dnf update -y && \
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 # AWS CLIのダウンロードとインストール
-ARG AWSCLI_VERSION=2.27.35
+ARG AWSCLI_VERSION=2.27.56
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o awscliv2.zip; \
@@ -128,13 +128,13 @@ RUN python3.12 -m pip install --no-cache-dir -U pip==25.1.1 && \
     python3.12 -m pipx ensurepath
 
 # Python関連ツールのインストール
-RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.36.1 && \
+RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.38.0 && \
     pipx install --pip-args='--no-cache-dir' yamllint==1.37.1 && \
     rm -rf /root/.local/pipx/logs/*
 
 # NPMパッケージのインストール（runtimeステージで実行）
 RUN npm install -g --omit=dev --no-progress npm@11.4.2 && \
     npm install -g --omit=dev --no-progress markdownlint-cli2@0.18.1 && \
-    npm install -g --omit=dev --no-progress secretlint@9.3.4 @secretlint/secretlint-rule-preset-recommend@9.3.1 && \
+    npm install -g --omit=dev --no-progress secretlint@10.2.1 @secretlint/secretlint-rule-preset-recommend@10.2.1 && \
     npm cache clean --force && \
     rm -rf /root/.npm/_logs

--- a/.github/workflows/DockerImageScan.yml
+++ b/.github/workflows/DockerImageScan.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install Syft (SBOM generator)
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/v1.27.1/install.sh | sh -s -- -b /usr/local/bin
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/v1.29.0/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Generate SBOM (CycloneDX format)
         run: |
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install Grype (Vulnerability scanner)
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/v0.94.0/install.sh | sh -s -- -b /usr/local/bin
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/v0.96.1/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Scan SBOM with Grype
         run: |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 ## DevContainer Base Image
 
-- public.ecr.aws/amazonlinux/amazonlinux:2023.7.20250623.1-minimal
+- public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250715.0-minimal
   - Using Amazon Linux 2023 minimal image
   - Using `dnf` as package manager
 
@@ -18,8 +18,8 @@ The DevContainer is configured with Linters and VS Code extensions.
 | Software | Version | Notes |
 | --- | ---: | --- |
 | actionlint | 1.7.7 | Linter for GitHub Actions |
-| awscli | 2.27.35 | AWS CLI |
-| ghalint | 1.5.1 | Linter for GitHub Actions |
+| awscli | 2.27.56 | AWS CLI |
+| ghalint | 1.5.3 | Linter for GitHub Actions |
 | hadolint | 2.12.0 | Linter for Dockerfile |
 | shellcheck | 0.10.0 | Linter for Bash |
 
@@ -29,13 +29,13 @@ The DevContainer is configured with Linters and VS Code extensions.
 | --- | ---: | --- |
 | markdownlint-cli2 | 0.18.1 | Linter for Markdown |
 | npm | 11.4.2 | Node.js package manager |
-| SecretLint | 9.3.4 | Secret detection tool |
+| SecretLint | 10.2.1 | Secret detection tool |
 
 ### Installed via pipx command
 
 | Software | Version | Notes |
 | --- | ---: | --- |
-| cfn-lint | 1.36.1 | Linter for CloudFormation |
+| cfn-lint | 1.38.0 | Linter for CloudFormation |
 | yamllint | 1.37.1 | Linter for YAML |
 
 ### Installed via dnf command
@@ -48,7 +48,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 | gzip | 1.12 | Compression tool |
 | nodejs20 | 20.19.2 | Node.js runtime |
 | nodejs20-npm | 10.8.2 | Node.js package manager (standard npm package manager) |
-| python3.12 | 3.12.10 | Python 3.12 |
+| python3.12 | 3.12.11 | Python 3.12 |
 | python3.12-pip | 23.2.1 | pip for Python 3.12 |
 | tar | 1.34 | Archive tool |
 | unzip | 6.0 | Decompression tool |

--- a/tests/docker_image_test.py
+++ b/tests/docker_image_test.py
@@ -46,7 +46,7 @@ def test_ghalint_is_installed(host: Host) -> None:
     """Test if ghalint is installed and has the correct version."""
     cmd = host.run("ghalint -v")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.5.1" in cmd.stdout  # noqa: S101
+    assert "1.5.3" in cmd.stdout  # noqa: S101
 
 
 def test_hadolint_is_installed(host: Host) -> None:
@@ -67,14 +67,14 @@ def test_aws_cli_is_installed(host: Host) -> None:
     """Test if AWS CLI is installed and has the correct version."""
     cmd = host.run("aws --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "2.27.35" in cmd.stdout  # noqa: S101
+    assert "2.27.56" in cmd.stdout  # noqa: S101
 
 
 def test_cfn_lint_is_installed(host: Host) -> None:
     """Test if cfn-lint is installed and has the correct version."""
     cmd = host.run("cfn-lint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.36.1" in cmd.stdout  # noqa: S101
+    assert "1.38.0" in cmd.stdout  # noqa: S101
 
 
 def test_yamllint_is_installed(host: Host) -> None:
@@ -95,7 +95,7 @@ def test_secretlint_is_installed(host: Host) -> None:
     """Test if secretlint is installed and has the correct version."""
     cmd = host.run("secretlint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "9.3.4" in cmd.stdout  # noqa: S101
+    assert "10.2.1" in cmd.stdout  # noqa: S101
 
 
 FILE_MODE_EXECUTABLE = 0o755


### PR DESCRIPTION
….20250715.0-minimal in /.devcontainer (#27)

* Bump amazonlinux/amazonlinux in /.devcontainer

Bumps amazonlinux/amazonlinux from 2023.7.20250623.1-minimal to 2023.8.20250715.0-minimal.

---
updated-dependencies:
- dependency-name: amazonlinux/amazonlinux dependency-version: 2023.8.20250715.0-minimal dependency-type: direct:production update-type: version-update:semver-minor ...



* Update tool versions in Dockerfile, CI workflow, and tests

---------