### PR TITLE
Bump amazonlinux/amazonlinux from 2023.8.20250715.0-minimal to 2023.8…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # ビルドステージ
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250715.0-minimal AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250721.2-minimal AS builder
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -68,7 +68,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # 実行環境
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250715.0-minimal
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250721.2-minimal
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -90,8 +90,9 @@ COPY --from=builder /tmp/tools/shellcheck-v0.10.0/shellcheck /usr/local/bin/
 # 開発に必要な基本ツールのインストール
 RUN dnf update -y && \
     dnf --releasever=latest install -y \
+    diffutils-3.8 \
     findutils-4.8.0 \
-    git-2.47.1 \
+    git-2.50.1 \
     glibc-locale-source-2.34 \
     gzip-1.12 \
     nodejs20-20.19.2 \
@@ -107,7 +108,7 @@ RUN dnf update -y && \
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 # AWS CLIのダウンロードとインストール
-ARG AWSCLI_VERSION=2.27.56
+ARG AWSCLI_VERSION=2.27.60
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o awscliv2.zip; \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 | Software | Version | Notes |
 | --- | ---: | --- |
 | actionlint | 1.7.7 | Linter for GitHub Actions |
-| awscli | 2.27.56 | AWS CLI |
+| awscli | 2.27.60 | AWS CLI |
 | ghalint | 1.5.3 | Linter for GitHub Actions |
 | hadolint | 2.12.0 | Linter for Dockerfile |
 | shellcheck | 0.10.0 | Linter for Bash |
@@ -42,8 +42,9 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 | Package Name | Version | Notes |
 | --- | ---: | --- |
+| diffutils | 3.8 | Finding differences between files |
 | findutils | 4.8.0 | File search utilities |
-| git | 2.47.1 | Git command |
+| git | 2.50.1 | Git command |
 | glibc-locale-source | 2.34 | Source for generating locale data |
 | gzip | 1.12 | Compression tool |
 | nodejs20 | 20.19.2 | Node.js runtime |

--- a/tests/docker_image_test.py
+++ b/tests/docker_image_test.py
@@ -67,7 +67,7 @@ def test_aws_cli_is_installed(host: Host) -> None:
     """Test if AWS CLI is installed and has the correct version."""
     cmd = host.run("aws --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "2.27.56" in cmd.stdout  # noqa: S101
+    assert "2.27.60" in cmd.stdout  # noqa: S101
 
 
 def test_cfn_lint_is_installed(host: Host) -> None:


### PR DESCRIPTION
….20250721.2-minimal in /.devcontainer (#34)

* Bump amazonlinux/amazonlinux in /.devcontainer

Bumps amazonlinux/amazonlinux from 2023.8.20250715.0-minimal to 2023.8.20250721.2-minimal.

---
updated-dependencies:
- dependency-name: amazonlinux/amazonlinux dependency-version: 2023.8.20250721.2-minimal dependency-type: direct:production update-type: version-update:semver-patch ...



* Update AWS CLI and Git versions in Dockerfile and README; add diffutils package

---------