### PR TITLE
Bump amazonlinux/amazonlinux from 2023.8.20250721.2-minimal to 2023.8…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # ビルドステージ
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250721.2-minimal AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250804.0-minimal AS builder
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -68,7 +68,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # 実行環境
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250721.2-minimal
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250804.0-minimal
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -100,6 +100,7 @@ RUN dnf update -y && \
     python3.12-3.12.11 \
     python3.12-pip-23.2.1 \
     tar-1.34 \
+    tree-1.8.0 \
     unzip-6.0 \
     xz-5.2.5 && \
     dnf clean all
@@ -108,7 +109,7 @@ RUN dnf update -y && \
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 # AWS CLIのダウンロードとインストール
-ARG AWSCLI_VERSION=2.28.1
+ARG AWSCLI_VERSION=2.28.6
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o awscliv2.zip; \
@@ -136,6 +137,6 @@ RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.38.0 && \
 # NPMパッケージのインストール（runtimeステージで実行）
 RUN npm install -g --omit=dev --no-progress npm@11.4.2 && \
     npm install -g --omit=dev --no-progress markdownlint-cli2@0.18.1 && \
-    npm install -g --omit=dev --no-progress secretlint@10.2.1 @secretlint/secretlint-rule-preset-recommend@10.2.1 && \
+    npm install -g --omit=dev --no-progress secretlint@11.0.1 @secretlint/secretlint-rule-preset-recommend@11.0.1 && \
     npm cache clean --force && \
     rm -rf /root/.npm/_logs

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 ## DevContainer Base Image
 
-- public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250715.0-minimal
+- public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250804.0-minimal
   - Using Amazon Linux 2023 minimal image
   - Using `dnf` as package manager
 
@@ -18,7 +18,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 | Software | Version | Notes |
 | --- | ---: | --- |
 | actionlint | 1.7.7 | Linter for GitHub Actions |
-| awscli | 2.28.1 | AWS CLI |
+| awscli | 2.28.6 | AWS CLI |
 | ghalint | 1.5.3 | Linter for GitHub Actions |
 | hadolint | 2.12.0 | Linter for Dockerfile |
 | shellcheck | 0.10.0 | Linter for Bash |
@@ -29,7 +29,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 | --- | ---: | --- |
 | markdownlint-cli2 | 0.18.1 | Linter for Markdown |
 | npm | 11.4.2 | Node.js package manager |
-| SecretLint | 10.2.1 | Secret detection tool |
+| SecretLint | 11.0.1 | Secret detection tool |
 
 ### Installed via pipx command
 
@@ -52,6 +52,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 | python3.12 | 3.12.11 | Python 3.12 |
 | python3.12-pip | 23.2.1 | pip for Python 3.12 |
 | tar | 1.34 | Archive tool |
+| tree | 1.8.0 | File system tree viewer |
 | unzip | 6.0 | Decompression tool |
 | xz | 5.2.5 | Compression tool |
 

--- a/tests/docker_image_test.py
+++ b/tests/docker_image_test.py
@@ -67,7 +67,7 @@ def test_aws_cli_is_installed(host: Host) -> None:
     """Test if AWS CLI is installed and has the correct version."""
     cmd = host.run("aws --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "2.28.1" in cmd.stdout  # noqa: S101
+    assert "2.28.6" in cmd.stdout  # noqa: S101
 
 
 def test_cfn_lint_is_installed(host: Host) -> None:
@@ -95,7 +95,7 @@ def test_secretlint_is_installed(host: Host) -> None:
     """Test if secretlint is installed and has the correct version."""
     cmd = host.run("secretlint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "10.2.1" in cmd.stdout  # noqa: S101
+    assert "11.0.1" in cmd.stdout  # noqa: S101
 
 
 FILE_MODE_EXECUTABLE = 0o755


### PR DESCRIPTION
….20250804.0-minimal in /.devcontainer (#40)

* Bump amazonlinux/amazonlinux in /.devcontainer

Bumps amazonlinux/amazonlinux from 2023.8.20250721.2-minimal to 2023.8.20250804.0-minimal.

---
updated-dependencies:
- dependency-name: amazonlinux/amazonlinux dependency-version: 2023.8.20250804.0-minimal dependency-type: direct:production update-type: version-update:semver-patch ...



* Update AWS CLI and SecretLint versions; add tree package to Dockerfile

---------