### PR TITLE
Update Python version from 3.12 to 3.13 in Dockerfile and README

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -97,8 +97,8 @@ RUN dnf update -y && \
     gzip-1.12 \
     nodejs20-20.19.2 \
     nodejs20-npm-10.8.2 \
-    python3.12-3.12.11 \
-    python3.12-pip-23.2.1 \
+    python3.13-3.13.3 \
+    python3.13-pip-24.2 \
     tar-1.34 \
     tree-1.8.0 \
     unzip-6.0 \
@@ -124,10 +124,10 @@ RUN BUILDARCH=$(uname -m) && \
     rm -rf awscliv2.zip aws
 
 # pipxのインストールと環境設定
-RUN python3.12 -m pip install --no-cache-dir -U pip==25.1.1 && \
-    python3.12 -m pip install --no-cache-dir pipx==1.7.1 && \
-    python3.12 -m pip install --no-cache-dir setuptools==80.9.0 && \
-    python3.12 -m pipx ensurepath
+RUN python3.13 -m pip install --no-cache-dir -U pip==25.1.1 && \
+    python3.13 -m pip install --no-cache-dir pipx==1.7.1 && \
+    python3.13 -m pip install --no-cache-dir setuptools==80.9.0 && \
+    python3.13 -m pipx ensurepath
 
 # Python関連ツールのインストール
 RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.38.0 && \

--- a/.github/workflows/DockerImageScan.yml
+++ b/.github/workflows/DockerImageScan.yml
@@ -30,8 +30,8 @@ jobs:
           persist-credentials: "false"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
-        # v3.11.1
+        # yamllint disable-line rule:line-length
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
 
       - name: Build Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload Grype report
         if: always() && (hashFiles('grype.sarif') != '')
-        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d
-        # v3.29.5
+        # yamllint disable-line rule:line-length
+        uses: github/codeql-action/upload-sarif@76621b61decf072c1cee8dd1ce2d2a82d33c17ed  # v3.29.8
         with:
           sarif_file: grype.sarif

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The DevContainer is configured with Linters and VS Code extensions.
 | gzip | 1.12 | Compression tool |
 | nodejs20 | 20.19.2 | Node.js runtime |
 | nodejs20-npm | 10.8.2 | Node.js package manager (standard npm package manager) |
-| python3.12 | 3.12.11 | Python 3.12 |
-| python3.12-pip | 23.2.1 | pip for Python 3.12 |
+| python3.13 | 3.13.3 | Python 3.13 |
+| python3.13-pip | 24.2 | pip for Python 3.13 |
 | tar | 1.34 | Archive tool |
 | tree | 1.8.0 | File system tree viewer |
 | unzip | 6.0 | Decompression tool |


### PR DESCRIPTION
This pull request updates the development environment to use Python 3.13 instead of Python 3.12, along with corresponding updates to pip and related tooling. It also includes minor improvements to workflow configuration comments and documentation.

**Python version upgrade:**

* Updated the base Python version and pip package in `.devcontainer/Dockerfile` from `python3.12`/`pip 23.2.1` to `python3.13`/`pip 24.2`, ensuring the environment uses the latest stable Python release.
* Changed all `python3.12` references to `python3.13` for pip, pipx, and setuptools installation commands in `.devcontainer/Dockerfile` to match the new Python version.
* Updated the Python version and pip package in the DevContainer tools table in `README.md` for documentation accuracy.

**Workflow configuration improvements:**

* Added `yamllint` directive comments to clarify line length exceptions in the workflow YAML file for better linting and maintainability. [[1]](diffhunk://#diff-a5d58c41a739c9eceb03df6dd2136f7a146fff0df6eaa38806a243645952501bL33-R34) [[2]](diffhunk://#diff-a5d58c41a739c9eceb03df6dd2136f7a146fff0df6eaa38806a243645952501bL83-R84)
* Updated the `github/codeql-action/upload-sarif` action to a newer commit hash (`v3.29.8`) in `.github/workflows/DockerImageScan.yml` for improved security and reliability.