### PR TITLE
Bump amazonlinux/amazonlinux from 2023.8.20250818.0-minimal to 2023.8…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # ビルドステージ
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250818.0-minimal AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250908.0-minimal AS builder
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -68,7 +68,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # 実行環境
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250818.0-minimal
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250908.0-minimal
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -131,7 +131,7 @@ RUN python3.13 -m pip install --no-cache-dir -U pip==25.1.1 && \
     python3.13 -m pipx ensurepath
 
 # Python関連ツールのインストール
-RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.38.0 && \
+RUN pipx install --pip-args='--no-cache-dir' cfn-lint==1.39.1 && \
     pipx install --pip-args='--no-cache-dir' yamllint==1.37.1 && \
     rm -rf /root/.local/pipx/logs/*
 

--- a/.github/workflows/DockerImageScan.yml
+++ b/.github/workflows/DockerImageScan.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Syft (SBOM generator)
         run: |
           curl -sSfL \
-            https://raw.githubusercontent.com/anchore/syft/v1.29.0/install.sh \
+            https://raw.githubusercontent.com/anchore/syft/v1.32.0/install.sh \
             | sh -s -- -b /usr/local/bin
 
       - name: Generate SBOM (CycloneDX format)
@@ -71,7 +71,7 @@ jobs:
       - name: Install Grype (Vulnerability scanner)
         run: |
           curl -sSfL \
-            https://raw.githubusercontent.com/anchore/grype/v0.96.1/install.sh \
+            https://raw.githubusercontent.com/anchore/grype/v0.99.1/install.sh \
             | sh -s -- -b /usr/local/bin
 
       - name: Scan SBOM with Grype

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 ## DevContainer Base Image
 
-- public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250818.0-minimal
+- public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250908.0-minimal
   - Using Amazon Linux 2023 minimal image
   - Using `dnf` as package manager
 
@@ -35,7 +35,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 | Software | Version | Notes |
 | --- | ---: | --- |
-| cfn-lint | 1.38.0 | Linter for CloudFormation |
+| cfn-lint | 1.39.1 | Linter for CloudFormation |
 | yamllint | 1.37.1 | Linter for YAML |
 
 ### Installed via dnf command

--- a/tests/docker_image_test.py
+++ b/tests/docker_image_test.py
@@ -74,7 +74,7 @@ def test_cfn_lint_is_installed(host: Host) -> None:
     """Test if cfn-lint is installed and has the correct version."""
     cmd = host.run("cfn-lint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.38.0" in cmd.stdout  # noqa: S101
+    assert "1.39.1" in cmd.stdout  # noqa: S101
 
 
 def test_yamllint_is_installed(host: Host) -> None:


### PR DESCRIPTION
….20250908.0-minimal in /.devcontainer (#58)

* Bump amazonlinux/amazonlinux in /.devcontainer

Bumps amazonlinux/amazonlinux from 2023.8.20250818.0-minimal to 2023.8.20250908.0-minimal.

---
updated-dependencies:
- dependency-name: amazonlinux/amazonlinux dependency-version: 2023.8.20250908.0-minimal dependency-type: direct:production update-type: version-update:semver-patch ...



* Updated cfn-lint version from 1.38.0 to 1.39.1 and fixed related tests. Updated the versions of the Syft and Grype install scripts used in Dockerfile image scanning.

---------