### PR TITLE
Bump amazonlinux/amazonlinux from 2023.8.20250915.0-minimal to 2023.9…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # ビルドステージ
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250915.0-minimal AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.9.20250929.0-minimal AS builder
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -17,7 +17,7 @@ RUN dnf update -y && \
     dnf clean all
 
 # actionlintのダウンロード
-ARG ACTIONLINT_VERSION=1.7.7
+ARG ACTIONLINT_VERSION=1.7.8
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -LO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" && \
@@ -68,7 +68,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # 実行環境
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250915.0-minimal
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.9.20250929.0-minimal
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -95,7 +95,7 @@ RUN dnf update -y && \
     git-2.50.1 \
     glibc-locale-source-2.34 \
     gzip-1.12 \
-    nodejs20-20.19.2 \
+    nodejs20-20.19.5 \
     nodejs20-npm-10.8.2 \
     python3.13-3.13.3 \
     python3.13-pip-24.2 \
@@ -109,7 +109,7 @@ RUN dnf update -y && \
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 # AWS CLIのダウンロードとインストール
-ARG AWSCLI_VERSION=2.31.3
+ARG AWSCLI_VERSION=2.31.13
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o awscliv2.zip; \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 ## DevContainer Base Image
 
-- public.ecr.aws/amazonlinux/amazonlinux:2023.8.20250915.0-minimal
+- public.ecr.aws/amazonlinux/amazonlinux:2023.9.20250929.0-minimal
   - Using Amazon Linux 2023 minimal image
   - Using `dnf` as package manager
 
@@ -17,8 +17,8 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 | Software | Version | Notes |
 | --- | ---: | --- |
-| actionlint | 1.7.7 | Linter for GitHub Actions |
-| awscli | 2.31.3 | AWS CLI |
+| actionlint | 1.7.8 | Linter for GitHub Actions |
+| awscli | 2.31.13 | AWS CLI |
 | ghalint | 1.5.3 | Linter for GitHub Actions |
 | hadolint | 2.12.0 | Linter for Dockerfile |
 | shellcheck | 0.10.0 | Linter for Bash |

--- a/tests/docker_image_test.py
+++ b/tests/docker_image_test.py
@@ -39,7 +39,7 @@ def test_actionlint_is_installed(host: Host) -> None:
     """Test if actionlint is installed and has the correct version."""
     cmd = host.run("actionlint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.7.7" in cmd.stdout  # noqa: S101
+    assert "1.7.8" in cmd.stdout  # noqa: S101
 
 
 def test_ghalint_is_installed(host: Host) -> None:
@@ -67,7 +67,7 @@ def test_aws_cli_is_installed(host: Host) -> None:
     """Test if AWS CLI is installed and has the correct version."""
     cmd = host.run("aws --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "2.31.3" in cmd.stdout  # noqa: S101
+    assert "2.31.13" in cmd.stdout  # noqa: S101
 
 
 def test_cfn_lint_is_installed(host: Host) -> None:


### PR DESCRIPTION
….20250929.0-minimal in /.devcontainer (#70)

* Bump amazonlinux/amazonlinux in /.devcontainer

Bumps amazonlinux/amazonlinux from 2023.8.20250915.0-minimal to 2023.9.20250929.0-minimal.

---
updated-dependencies:
- dependency-name: amazonlinux/amazonlinux dependency-version: 2023.9.20250929.0-minimal dependency-type: direct:production update-type: version-update:semver-minor ...



* Update actionlint and AWS CLI versions in Dockerfile and tests

---------