### PR TITLE
Update amazonlinux version and clean up README installation section

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # ビルドステージ
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.9.20250929.0-minimal AS builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.11.20260526.0-minimal AS builder
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -17,7 +17,7 @@ RUN dnf update -y && \
     dnf clean all
 
 # actionlintのダウンロード
-ARG ACTIONLINT_VERSION=1.7.8
+ARG ACTIONLINT_VERSION=1.7.12
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -LO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" && \
@@ -30,7 +30,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # ghalintのダウンロード
-ARG GHALINT_VERSION=1.5.3
+ARG GHALINT_VERSION=1.5.6
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -LO "https://github.com/suzuki-shunsuke/ghalint/releases/download/v${GHALINT_VERSION}/ghalint_${GHALINT_VERSION}_linux_amd64.tar.gz" && \
@@ -43,7 +43,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # hadolintのダウンロード
-ARG HADOLINT_VERSION=2.12.0
+ARG HADOLINT_VERSION=2.14.0
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -L "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" -o hadolint; \
@@ -55,7 +55,7 @@ RUN BUILDARCH=$(uname -m) && \
     chmod +x hadolint
 
 # shellcheckのダウンロード
-ARG SHELLCHECK_VERSION=0.10.0
+ARG SHELLCHECK_VERSION=0.11.0
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -LO "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" && \
@@ -68,7 +68,7 @@ RUN BUILDARCH=$(uname -m) && \
     fi
 
 # 実行環境
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.9.20250929.0-minimal
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.11.20260526.0-minimal
 
 # シェルオプションの設定
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -85,7 +85,7 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /tmp/tools/actionlint /usr/local/bin/
 COPY --from=builder /tmp/tools/ghalint /usr/local/bin/
 COPY --from=builder /tmp/tools/hadolint /usr/local/bin/
-COPY --from=builder /tmp/tools/shellcheck-v0.10.0/shellcheck /usr/local/bin/
+COPY --from=builder /tmp/tools/shellcheck-v0.11.0/shellcheck /usr/local/bin/
 
 # 開発に必要な基本ツールのインストール
 RUN dnf update -y && \
@@ -95,10 +95,10 @@ RUN dnf update -y && \
     git-2.50.1 \
     glibc-locale-source-2.34 \
     gzip-1.12 \
-    nodejs20-20.19.5 \
-    nodejs20-npm-10.8.2 \
-    python3.13-3.13.3 \
-    python3.13-pip-24.2 \
+    nodejs24-24.15.0 \
+    nodejs24-npm-11.12.1 \
+    python3.14-3.14.4 \
+    python3.14-pip-25.1.1 \
     tar-1.34 \
     tree-1.8.0 \
     unzip-6.0 \
@@ -110,7 +110,7 @@ RUN dnf update -y && \
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 # AWS CLIのダウンロードとインストール
-ARG AWSCLI_VERSION=2.31.13
+ARG AWSCLI_VERSION=2.34.57
 RUN BUILDARCH=$(uname -m) && \
     if [ "${BUILDARCH}" = "x86_64" ]; then \
         curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o awscliv2.zip; \
@@ -128,10 +128,10 @@ RUN BUILDARCH=$(uname -m) && \
 COPY .devcontainer/bootstrap-requirements.txt /tmp/bootstrap-requirements.txt
 COPY .devcontainer/requirements.txt /tmp/requirements.txt
 # hadolint ignore=DL3013
-RUN python3.13 -m pip install --no-cache-dir --requirement /tmp/bootstrap-requirements.txt && \
+RUN python3.14 -m pip install --no-cache-dir --requirement /tmp/bootstrap-requirements.txt && \
     while IFS= read -r package; do \
         [[ -z "${package}" || "${package}" =~ ^# ]] && continue; \
-        pipx install --python python3.13 --pip-args=--no-cache-dir "${package}"; \
+        pipx install --python python3.14 --pip-args=--no-cache-dir "${package}"; \
     done < /tmp/requirements.txt && \
     rm /tmp/bootstrap-requirements.txt /tmp/requirements.txt
 

--- a/.devcontainer/bootstrap-requirements.txt
+++ b/.devcontainer/bootstrap-requirements.txt
@@ -1,3 +1,3 @@
-pip==25.2
-pipx==1.7.1
-setuptools==80.9.0
+pip==26.1.1
+pipx==1.12.0
+setuptools==82.0.1

--- a/.devcontainer/package.json
+++ b/.devcontainer/package.json
@@ -2,9 +2,9 @@
   "name": "devcontainer",
   "private": true,
   "dependencies": {
-    "npm": "11.4.2",
-    "markdownlint-cli2": "0.18.1",
-    "secretlint": "11.0.1",
-    "@secretlint/secretlint-rule-preset-recommend": "11.0.1"
+    "npm": "11.15.0",
+    "markdownlint-cli2": "0.22.1",
+    "secretlint": "13.0.2",
+    "@secretlint/secretlint-rule-preset-recommend": "13.0.2"
   }
 }

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,3 +1,3 @@
-uv==0.8.12
-cfn-lint==1.39.1
-yamllint==1.37.1
+uv==0.11.16
+cfn-lint==1.51.1
+yamllint==1.38.0

--- a/.github/workflows/DockerImageScan.yml
+++ b/.github/workflows/DockerImageScan.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Syft (SBOM generator)
         run: |
           curl -sSfL \
-            https://raw.githubusercontent.com/anchore/syft/v1.32.0/install.sh \
+            https://raw.githubusercontent.com/anchore/syft/v1.44.0/install.sh \
             | sh -s -- -b /usr/local/bin
 
       - name: Generate SBOM (CycloneDX format)
@@ -74,7 +74,7 @@ jobs:
       - name: Install Grype (Vulnerability scanner)
         run: |
           curl -sSfL \
-            https://raw.githubusercontent.com/anchore/grype/v0.99.1/install.sh \
+            https://raw.githubusercontent.com/anchore/grype/v0.112.0/install.sh \
             | sh -s -- -b /usr/local/bin
 
       - name: Scan SBOM with Grype

--- a/README.md
+++ b/README.md
@@ -17,27 +17,35 @@ The DevContainer is configured with Linters and VS Code extensions.
 
 | Software | Version | Notes |
 | --- | ---: | --- |
-| actionlint | 1.7.8 | Linter for GitHub Actions |
-| awscli | 2.31.13 | AWS CLI |
-| ghalint | 1.5.3 | Linter for GitHub Actions |
-| hadolint | 2.12.0 | Linter for Dockerfile |
-| shellcheck | 0.10.0 | Linter for Bash |
+| actionlint | 1.7.12 | Linter for GitHub Actions |
+| awscli | 2.34.57 | AWS CLI |
+| ghalint | 1.5.6 | Linter for GitHub Actions |
+| hadolint | 2.14.0 | Linter for Dockerfile |
+| shellcheck | 0.11.0 | Linter for Bash |
 
 ### Installed via npm command
 
 | Software | Version | Notes |
 | --- | ---: | --- |
-| markdownlint-cli2 | 0.18.1 | Linter for Markdown |
-| npm | 11.4.2 | Node.js package manager |
-| SecretLint | 11.0.1 | Secret detection tool |
+| markdownlint-cli2 | 0.22.1 | Linter for Markdown |
+| npm | 11.15.0 | Node.js package manager |
+| SecretLint | 13.0.2 | Secret detection tool |
 
 ### Installed via pipx command
 
 | Software | Version | Notes |
 | --- | ---: | --- |
-| cfn-lint | 1.39.1 | Linter for CloudFormation |
-| uv | 0.8.12 | Python package and project manager |
-| yamllint | 1.37.1 | Linter for YAML |
+| cfn-lint | 1.51.1 | Linter for CloudFormation |
+| uv | 0.11.16 | Python package and project manager |
+| yamllint | 1.38.0 | Linter for YAML |
+
+### Installed via pip command
+
+| Software | Version | Notes |
+| --- | ---: | --- |
+| pip | 26.1.1 | Bootstrap package manager for Python tooling |
+| pipx | 1.12.0 | Isolated installer for Python CLI tools |
+| setuptools | 82.0.1 | Bootstrap build backend for Python tooling |
 
 ### Installed via pip command
 
@@ -56,10 +64,10 @@ The DevContainer is configured with Linters and VS Code extensions.
 | git | 2.50.1 | Git command |
 | glibc-locale-source | 2.34 | Source for generating locale data |
 | gzip | 1.12 | Compression tool |
-| nodejs20 | 20.19.2 | Node.js runtime |
-| nodejs20-npm | 10.8.2 | Node.js package manager (standard npm package manager) |
-| python3.13 | 3.13.3 | Python 3.13 |
-| python3.13-pip | 24.2 | pip for Python 3.13 |
+| nodejs24 | 24.15.0 | Node.js runtime |
+| nodejs24-npm | 11.12.1 | Node.js package manager (standard npm package manager) |
+| python3.14 | 3.14.4 | Python 3.14 |
+| python3.14-pip | 25.1.1 | pip for Python 3.14 |
 | tar | 1.34 | Archive tool |
 | tree | 1.8.0 | File system tree viewer |
 | unzip | 6.0 | Decompression tool |

--- a/README.md
+++ b/README.md
@@ -47,14 +47,6 @@ The DevContainer is configured with Linters and VS Code extensions.
 | pipx | 1.12.0 | Isolated installer for Python CLI tools |
 | setuptools | 82.0.1 | Bootstrap build backend for Python tooling |
 
-### Installed via pip command
-
-| Software | Version | Notes |
-| --- | ---: | --- |
-| pip | 25.2 | Bootstrap package manager for Python tooling |
-| pipx | 1.7.1 | Isolated installer for Python CLI tools |
-| setuptools | 80.9.0 | Bootstrap build backend for Python tooling |
-
 ### Installed via dnf command
 
 | Package Name | Version | Notes |

--- a/tests/docker_image_test.py
+++ b/tests/docker_image_test.py
@@ -39,63 +39,63 @@ def test_actionlint_is_installed(host: Host) -> None:
     """Test if actionlint is installed and has the correct version."""
     cmd = host.run("actionlint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.7.8" in cmd.stdout  # noqa: S101
+    assert "1.7.12" in cmd.stdout  # noqa: S101
 
 
 def test_ghalint_is_installed(host: Host) -> None:
     """Test if ghalint is installed and has the correct version."""
     cmd = host.run("ghalint -v")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.5.3" in cmd.stdout  # noqa: S101
+    assert "1.5.6" in cmd.stdout  # noqa: S101
 
 
 def test_hadolint_is_installed(host: Host) -> None:
     """Test if hadolint is installed and has the correct version."""
     cmd = host.run("hadolint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "2.12.0" in cmd.stdout  # noqa: S101
+    assert "2.14.0" in cmd.stdout  # noqa: S101
 
 
 def test_shellcheck_is_installed(host: Host) -> None:
     """Test if shellcheck is installed and has the correct version."""
     cmd = host.run("shellcheck --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "0.10.0" in cmd.stdout  # noqa: S101
+    assert "0.11.0" in cmd.stdout  # noqa: S101
 
 
 def test_aws_cli_is_installed(host: Host) -> None:
     """Test if AWS CLI is installed and has the correct version."""
     cmd = host.run("aws --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "2.31.13" in cmd.stdout  # noqa: S101
+    assert "2.34.57" in cmd.stdout  # noqa: S101
 
 
 def test_cfn_lint_is_installed(host: Host) -> None:
     """Test if cfn-lint is installed and has the correct version."""
     cmd = host.run("cfn-lint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.39.1" in cmd.stdout  # noqa: S101
+    assert "1.51.1" in cmd.stdout  # noqa: S101
 
 
 def test_yamllint_is_installed(host: Host) -> None:
     """Test if yamllint is installed and has the correct version."""
     cmd = host.run("yamllint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "1.37.1" in cmd.stdout  # noqa: S101
+    assert "1.38.0" in cmd.stdout  # noqa: S101
 
 
 def test_markdownlint_is_installed(host: Host) -> None:
     """Test if markdownlint is installed and has the correct version."""
     cmd = host.run("markdownlint-cli2 --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "0.18.1" in cmd.stdout  # noqa: S101
+    assert "0.22.1" in cmd.stdout  # noqa: S101
 
 
 def test_secretlint_is_installed(host: Host) -> None:
     """Test if secretlint is installed and has the correct version."""
     cmd = host.run("secretlint --version")
     assert cmd.rc == 0  # noqa: S101
-    assert "11.0.1" in cmd.stdout  # noqa: S101
+    assert "13.0.2" in cmd.stdout  # noqa: S101
 
 
 FILE_MODE_EXECUTABLE = 0o755


### PR DESCRIPTION
This pull request updates the DevContainer environment to use newer versions of its base images, linters, developer tools, and supporting libraries. The updates span the Dockerfile, dependency files, workflow scripts, documentation, and test assertions to ensure consistency and compatibility across the development environment.

The most important changes are:

**Base Image and Core Toolchain Updates**
- Upgraded the Amazon Linux base image from `2023.9.20250929.0-minimal` to `2023.11.20260526.0-minimal` in both build and runtime stages of `.devcontainer/Dockerfile`. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L2-R2) [[2]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L71-R71)
- Updated Node.js from version 20 to 24 and Python from 3.13 to 3.14, including their respective npm and pip packages in `.devcontainer/Dockerfile` and the documentation. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L98-R101) [[2]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L131-R134) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R62)

**Linter and CLI Tool Version Upgrades**
- Upgraded versions of key linters and CLI tools: `actionlint` to 1.7.12, `ghalint` to 1.5.6, `hadolint` to 2.14.0, `shellcheck` to 0.11.0, and `awscli` to 2.34.57. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L20-R20) [[2]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L33-R33) [[3]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L46-R46) [[4]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L58-R58) [[5]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L113-R113) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R48)
- Updated npm-installed tools: `markdownlint-cli2` to 0.22.1, `npm` to 11.15.0, `secretlint` and its rule preset to 13.0.2 in `.devcontainer/package.json` and documentation. [[1]](diffhunk://#diff-1d7abd97b5386d2238f5761095b6e05f0e6905eec59c48b3ab1b2e51f0f084acL5-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R48)

**Python Package and Pipx Tooling Updates**
- Upgraded Python-related packages: `pip` to 26.1.1, `pipx` to 1.12.0, and `setuptools` to 82.0.1 in `.devcontainer/bootstrap-requirements.txt` and documentation. [[1]](diffhunk://#diff-7e90afc2171f1c2f8297dfaaec067d3ea4a532756e5cbaa2670532dce0f654feL1-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R48)
- Updated pipx-installed tools: `uv` to 0.11.16, `cfn-lint` to 1.51.1, and `yamllint` to 1.38.0 in `.devcontainer/requirements.txt` and documentation. [[1]](diffhunk://#diff-087d0a5bf5aeb4b21f5d8766c9500e215b58c608b043912173fa514207ac6a96L1-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R48)

**CI Workflow Tooling Upgrades**
- Upgraded versions of Syft (SBOM generator) to 1.44.0 and Grype (vulnerability scanner) to 0.112.0 in `.github/workflows/DockerImageScan.yml`. [[1]](diffhunk://#diff-a5d58c41a739c9eceb03df6dd2136f7a146fff0df6eaa38806a243645952501bL66-R66) [[2]](diffhunk://#diff-a5d58c41a739c9eceb03df6dd2136f7a146fff0df6eaa38806a243645952501bL77-R77)

**Documentation and Test Synchronization**
- Updated `README.md` to reflect all new tool and dependency versions for consistency and clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R62)
- Updated `tests/docker_image_test.py` to assert the new versions of all upgraded tools, ensuring the test suite validates the correct environment.