### PR TITLE
Bump npm from 11.15.0 to 11.16.0 in /.devcontainer (#132)

### DIFF
--- a/.devcontainer/.npmrc
+++ b/.devcontainer/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=7
+ignore-scripts=true

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -140,6 +140,7 @@ RUN python3.14 -m pip install --no-cache-dir --requirement /tmp/bootstrap-requir
     rm /tmp/bootstrap-requirements.txt /tmp/requirements.txt
 
 # NPMパッケージのインストール
+COPY .devcontainer/.npmrc /opt/node/.npmrc
 COPY .devcontainer/package.json /opt/node/package.json
 WORKDIR /opt/node
 RUN npm install --omit=dev --no-progress && \

--- a/.devcontainer/package.json
+++ b/.devcontainer/package.json
@@ -2,7 +2,7 @@
   "name": "devcontainer",
   "private": true,
   "dependencies": {
-    "npm": "11.15.0",
+    "npm": "11.16.0",
     "markdownlint-cli2": "0.22.1",
     "secretlint": "13.0.2",
     "@secretlint/secretlint-rule-preset-recommend": "13.0.2"


### PR DESCRIPTION
* Bump npm from 11.15.0 to 11.16.0 in /.devcontainer

Bumps [npm](https://github.com/npm/cli) from 11.15.0 to 11.16.0.
- [Release notes](https://github.com/npm/cli/releases)
- [Changelog](https://github.com/npm/cli/blob/v11.16.0/CHANGELOG.md)
- [Commits](https://github.com/npm/cli/compare/v11.15.0...v11.16.0)

---
updated-dependencies:
- dependency-name: npm dependency-version: 11.16.0 dependency-type: direct:production update-type: version-update:semver-minor ...

* add .npmrc

---------